### PR TITLE
Day 7 - Refactor to calculate via triangle numbers

### DIFF
--- a/src/aoc2021/day07.py
+++ b/src/aoc2021/day07.py
@@ -18,8 +18,8 @@ def calc_constant_costs(crabs: List[int]) -> Dict[int, int]:
 
 
 @cache
-def increasing_move_cost(distance: int) -> int:
-    return sum(range(distance + 1))
+def triangle(num: int) -> int:
+    return num * (num + 1) / 2
 
 
 def calc_increasing_cost(crabs: List[int], pos: int) -> int:
@@ -27,7 +27,7 @@ def calc_increasing_cost(crabs: List[int], pos: int) -> int:
     for crab in crabs:
         diff = abs(crab - pos)
         if diff > 0:
-            cost += increasing_move_cost(diff)
+            cost += triangle(diff)
     return cost
 
 


### PR DESCRIPTION
Update part 2 solution to calculate via triangle numbers rather than summing a range. This is slightly faster with the same use of `cache`, but much faster when neither approach uses `cache` (~1s compared to ~22-25s).